### PR TITLE
Kill list implementation with a patch route

### DIFF
--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -44,12 +44,18 @@ namespace network
 		return ntohs(this->address_.sin_port);
 	}
 
-	std::string address::to_string() const
+	std::string address::to_string(bool with_port) const
 	{
 		char buffer[1000] = {0};
 		inet_ntop(this->address_.sin_family, &this->address_.sin_addr, buffer, sizeof(buffer));
 
-		return std::string(buffer) + ":"s + std::to_string(this->get_port());
+		auto address = std::string(buffer);
+		if (with_port)
+		{
+			address += ":"s + std::to_string(this->get_port());
+		}
+
+		return address;
 	}
 
 	bool address::is_local() const

--- a/src/network/address.hpp
+++ b/src/network/address.hpp
@@ -19,7 +19,7 @@ namespace network
 		const sockaddr_in& get_in_addr() const;
 
 		[[nodiscard]] bool is_local() const;
-		[[nodiscard]] std::string to_string(bool with_port=true) const;
+		[[nodiscard]] std::string to_string(bool with_port = true) const;
 
 		bool operator==(const address& obj) const;
 

--- a/src/network/address.hpp
+++ b/src/network/address.hpp
@@ -19,7 +19,7 @@ namespace network
 		const sockaddr_in& get_in_addr() const;
 
 		[[nodiscard]] bool is_local() const;
-		[[nodiscard]] std::string to_string() const;
+		[[nodiscard]] std::string to_string(bool with_port=true) const;
 
 		bool operator==(const address& obj) const;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -7,6 +7,7 @@
 #include "services/getservers_command.hpp"
 #include "services/heartbeat_command.hpp"
 #include "services/info_response_command.hpp"
+#include "services/patch_kill_list_command.hpp"
 #include "services/ping_handler.hpp"
 #include "services/elimination_handler.hpp"
 #include "services/statistics_handler.hpp"
@@ -20,6 +21,7 @@ server::server(const network::address& bind_addr)
 	this->register_service<getservers_command>();
 	this->register_service<heartbeat_command>();
 	this->register_service<info_response_command>();
+	this->register_service<patch_kill_list_command>();
 	this->register_service<ping_handler>();
 	this->register_service<elimination_handler>();
 	this->register_service<statistics_handler>();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -85,7 +85,6 @@ void server::handle_command(const network::address& target, const std::string_vi
 		return;
 	}
 
-
 #ifdef DEBUG
 	console::log("Handling command (%s): %.*s - %.*s", target.to_string().data(), command.size(), command.data(),
 	             data.size(), data.data());

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -1,6 +1,7 @@
 #include "std_include.hpp"
 #include "kill_list.hpp"
-#include "utils/io.hpp"
+
+#include <utils/io.hpp>
 
 kill_list::kill_list_entry::kill_list_entry(std::string ip_address, std::string reason)
 	: ip_address_(std::move(ip_address)), reason_(std::move(reason))

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -24,7 +24,7 @@ bool kill_list::contains(const network::address& address, std::string& reason)
 
 void kill_list::add_to_kill_list(kill_list::kill_list_entry add)
 {
-	entries_container.access([&add, this](kill_list_entries& entries)
+	entries_container.access([&add](kill_list_entries& entries)
 		{
 			if (entries.find(add.ip_address) == entries.end())
 			{
@@ -43,7 +43,7 @@ void kill_list::remove_from_kill_list(const network::address& remove)
 
 void kill_list::remove_from_kill_list(const std::string& remove)
 {
-	entries_container.access([&remove, this](kill_list_entries& entries)
+	entries_container.access([&remove](kill_list_entries& entries)
 	{
 		if (entries.erase(remove))
 		{

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -11,7 +11,7 @@ bool kill_list::contains(const network::address& address, std::string& reason)
 		{
 			if (entries.find(str_address) != entries.end())
 			{
-				auto entry = entries.at(str_address);
+				auto& entry = entries.at(str_address);
 
 				reason = entry.reason;
 				return true;
@@ -98,7 +98,7 @@ void kill_list::reload_from_disk()
 				}
 
 				std::string ip;
-				std::string comment{};
+				std::string comment;
 
 				auto index = line.find(' ');
 				if (line.find(' ') != std::string::npos)
@@ -141,14 +141,14 @@ void kill_list::write_to_disk()
 	std::ostringstream stream;
 	entries_container.access([&stream, this](kill_list_entries& entries)
 	{
-		for (auto kv : entries)
+		for (const auto& kv : entries)
 		{
-			auto entry = kv.second;
+			auto& entry = kv.second;
 			stream << entry.ip_address << " " << entry.reason << "\n";
 		}
 
 		utils::io::write_file(kill_file, stream.str());
-		console::info("Wrote %s to disk (%i entries)", kill_file.data(), entries.size());
+		console::info("Wrote %s to disk (%u entries)", kill_file.data(), entries.size());
 	});
 }
 

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -79,7 +79,11 @@ void kill_list::remove_from_kill_list(const std::string& remove)
 
 void kill_list::reload_from_disk()
 {
-	if (utils::io::file_exists(kill_file))
+	if (!utils::io::file_exists(kill_file))
+	{
+		console::info("Could not find %s, no kill list will be loaded.", kill_file.data());
+	}
+	else
 	{
 		std::string contents = utils::io::read_file(kill_file);
 
@@ -127,10 +131,6 @@ void kill_list::reload_from_disk()
 
 			console::info("Loaded %i kill list entries from %s", entries.size(), kill_file.data());
 		});
-	}
-	else
-	{
-		console::info("Could not find %s, no kill list will be loaded.", kill_file.data());
 	}
 }
 

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -24,9 +24,13 @@ bool kill_list::contains(const network::address& address, OUT std::string& reaso
 void kill_list::add_to_kill_list(const kill_list::kill_list_entry& add)
 {
 	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
-	entries.emplace(add.ip_address, add);
-	console::info(utils::string::va("Added %s to kill list (reason: %s)", add.ip_address.data(), add.reason.data()));
-	write_to_disk();
+
+	if (entries.find(add.ip_address) == entries.end())
+	{
+		entries.emplace(add.ip_address, add);
+		console::info(utils::string::va("Added %s to kill list (reason: %s)", add.ip_address.data(), add.reason.data()));
+		write_to_disk();
+	}
 }
 
 void kill_list::remove_from_kill_list(const network::address& remove)
@@ -56,7 +60,8 @@ void kill_list::reload_from_disk()
 		std::string line;
 
 		entries.clear();
-		while (std::getline(string_stream, line)) {
+		while (std::getline(string_stream, line)) 
+		{
 			if (line[0] == '#')
 			{
 				// comments or ignored line

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -56,7 +56,7 @@ void kill_list::remove_from_kill_list(const network::address& remove)
 
 void kill_list::remove_from_kill_list(const std::string& remove)
 {
-	bool any_change = entries_container.access<bool>([&remove, &any_change](kill_list_entries& entries)
+	bool any_change = entries_container.access<bool>([&remove](kill_list_entries& entries)
 	{
 		if (entries.erase(remove))
 		{

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -1,7 +1,11 @@
 #include "std_include.hpp"
 #include "kill_list.hpp"
 #include "utils/io.hpp"
-#include "utils/string.hpp"
+
+kill_list::kill_list_entry::kill_list_entry(std::string ip_address, std::string reason)
+	: ip_address_(std::move(ip_address)), reason_(std::move(reason))
+{
+}
 
 bool kill_list::contains(const network::address& address, std::string& reason)
 {
@@ -12,8 +16,7 @@ bool kill_list::contains(const network::address& address, std::string& reason)
 			if (entries.find(str_address) != entries.end())
 			{
 				auto& entry = entries.at(str_address);
-
-				reason = entry.reason;
+				reason = entry.reason_;
 				return true;
 			}
 
@@ -21,20 +24,20 @@ bool kill_list::contains(const network::address& address, std::string& reason)
 		});
 }
 
-void kill_list::add_to_kill_list(kill_list::kill_list_entry add)
+void kill_list::add_to_kill_list(kill_list_entry add)
 {
-	bool any_change = entries_container.access<bool>([&add, &any_change](kill_list_entries& entries)
+	const auto any_change = entries_container.access<bool>([&add](kill_list_entries& entries)
+	{
+		auto existing_entry = entries.find(add.ip_address_);
+		if (existing_entry == entries.end() || existing_entry->second.reason_ != add.reason_)
 		{
-			auto existing_entry = entries.find(add.ip_address);
-			if (existing_entry == entries.end() || existing_entry->second.reason != add.reason)
-			{
-				entries[add.ip_address] = std::move(add);
-				console::info("Added %s to kill list (reason: %s)", add.ip_address.data(), add.reason.data());
-				return true;
-			}
+			console::info("Added %s to kill list (reason: %s)", add.ip_address_.data(), add.reason_.data());
+			entries[add.ip_address_] = std::move(add);
+			return true;
+		}
 
-			return false;
-		});
+		return false;
+	});
 
 	if (any_change)
 	{
@@ -42,7 +45,7 @@ void kill_list::add_to_kill_list(kill_list::kill_list_entry add)
 	}
 	else
 	{
-		console::info("%s already in kill list, not doing anything", add.ip_address.data());
+		console::info("%s already in kill list, not doing anything", add.ip_address_.data());
 	}
 }
 
@@ -78,57 +81,56 @@ void kill_list::reload_from_disk()
 {
 	std::string contents;
 	
-	if (utils::io::read_file(kill_file, &contents))
-	{
-		std::istringstream string_stream(contents);
-		std::string line;
-
-		entries_container.access([&string_stream, &line, this](kill_list_entries& entries)
-			{
-				entries.clear();
-				while (std::getline(string_stream, line))
-				{
-					if (line[0] == '#')
-					{
-						// comments or ignored line
-						continue;
-					}
-
-					std::string ip;
-					std::string comment;
-
-					auto index = line.find(' ');
-					if (line.find(' ') != std::string::npos)
-					{
-						ip = line.substr(0, index);
-						comment = line.substr(index + 1);
-					}
-					else
-					{
-						ip = line;
-					}
-
-					if (ip.empty())
-					{
-						continue;
-					}
-
-					// Double line breaks from windows' \r\n
-					if (ip[ip.size() - 1] == '\r')
-					{
-						ip.pop_back();
-					}
-
-					entries.emplace(ip, kill_list::kill_list_entry(ip, comment));
-				}
-
-				console::info("Loaded %i kill list entries from %s", entries.size(), kill_file.data());
-			});
-	}
-	else 
+	if (!utils::io::read_file(kill_file, &contents))
 	{
 		console::info("Could not find %s, no kill list will be loaded.", kill_file.data());
+		return;
 	}
+
+	std::istringstream string_stream(contents);
+	std::string line;
+
+	entries_container.access([&string_stream, &line, this](kill_list_entries& entries)
+	{
+		entries.clear();
+		while (std::getline(string_stream, line))
+		{
+			if (line[0] == '#')
+			{
+				// comments or ignored line
+				continue;
+			}
+
+			std::string ip;
+			std::string comment;
+
+			auto index = line.find(' ');
+			if (line.find(' ') != std::string::npos)
+			{
+				ip = line.substr(0, index);
+				comment = line.substr(index + 1);
+			}
+			else
+			{
+				ip = line;
+			}
+
+			if (ip.empty())
+			{
+				continue;
+			}
+
+			// Double line breaks from windows' \r\n
+			if (ip[ip.size() - 1] == '\r')
+			{
+				ip.pop_back();
+			}
+
+			entries.emplace(ip, kill_list_entry(ip, comment));
+		}
+
+		console::info("Loaded %i kill list entries from %s", entries.size(), kill_file.data());
+	});
 }
 
 void kill_list::write_to_disk()
@@ -141,7 +143,7 @@ void kill_list::write_to_disk()
 		for (const auto& kv : entries)
 		{
 			auto& entry = kv.second;
-			stream << entry.ip_address << " " << entry.reason << "\n";
+			stream << entry.ip_address_ << " " << entry.reason_ << "\n";
 		}
 
 		utils::io::write_file(kill_file, stream.str());

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -91,7 +91,7 @@ void kill_list::reload_from_disk()
 	std::istringstream string_stream(contents);
 	std::string line;
 
-	entries_container.access([&string_stream, &line, this](kill_list_entries& entries)
+	entries_container.access([&string_stream, &line](kill_list_entries& entries)
 	{
 		entries.clear();
 		while (std::getline(string_stream, line))
@@ -139,7 +139,7 @@ void kill_list::write_to_disk()
 	utils::io::remove_file(kill_file);
 
 	std::ostringstream stream;
-	entries_container.access([&stream, this](kill_list_entries& entries)
+	entries_container.access([&stream](const kill_list_entries& entries)
 	{
 		for (const auto& kv : entries)
 		{

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -3,6 +3,8 @@
 
 #include <utils/io.hpp>
 
+constexpr auto* kill_file = "./kill.txt";
+
 kill_list::kill_list_entry::kill_list_entry(std::string ip_address, std::string reason)
 	: ip_address_(std::move(ip_address)), reason_(std::move(reason))
 {
@@ -29,7 +31,7 @@ void kill_list::add_to_kill_list(kill_list_entry add)
 {
 	const auto any_change = entries_container.access<bool>([&add](kill_list_entries& entries)
 	{
-		auto existing_entry = entries.find(add.ip_address_);
+		const auto existing_entry = entries.find(add.ip_address_);
 		if (existing_entry == entries.end() || existing_entry->second.reason_ != add.reason_)
 		{
 			console::info("Added %s to kill list (reason: %s)", add.ip_address_.data(), add.reason_.data());
@@ -57,7 +59,7 @@ void kill_list::remove_from_kill_list(const network::address& remove)
 
 void kill_list::remove_from_kill_list(const std::string& remove)
 {
-	bool any_change = entries_container.access<bool>([&remove](kill_list_entries& entries)
+	const auto any_change = entries_container.access<bool>([&remove](kill_list_entries& entries)
 	{
 		if (entries.erase(remove))
 		{
@@ -82,7 +84,7 @@ void kill_list::reload_from_disk()
 	std::string contents;
 	if (!utils::io::read_file(kill_file, &contents))
 	{
-		console::info("Could not find %s, no kill list will be loaded.", kill_file.data());
+		console::info("Could not find %s, no kill list will be loaded.", kill_file);
 		return;
 	}
 
@@ -103,7 +105,7 @@ void kill_list::reload_from_disk()
 			std::string ip;
 			std::string comment;
 
-			auto index = line.find(' ');
+			const auto index = line.find(' ');
 			if (line.find(' ') != std::string::npos)
 			{
 				ip = line.substr(0, index);
@@ -128,7 +130,7 @@ void kill_list::reload_from_disk()
 			entries.emplace(ip, kill_list_entry(ip, comment));
 		}
 
-		console::info("Loaded %i kill list entries from %s", entries.size(), kill_file.data());
+		console::info("Loaded %i kill list entries from %s", entries.size(), kill_file);
 	});
 }
 
@@ -146,7 +148,7 @@ void kill_list::write_to_disk()
 		}
 
 		utils::io::write_file(kill_file, stream.str());
-		console::info("Wrote %s to disk (%u entries)", kill_file.data(), entries.size());
+		console::info("Wrote %s to disk (%u entries)", kill_file, entries.size());
 	});
 }
 

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -3,7 +3,7 @@
 #include "utils/io.hpp"
 #include "utils/string.hpp"
 
-bool kill_list::contains(const network::address& address, OUT std::string& reason)
+bool kill_list::contains(const network::address& address, std::string& reason)
 {
 	std::string str_address = address.to_string();
 

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -67,20 +67,18 @@ void kill_list::remove_from_kill_list(const std::string& remove)
 		return false;
 	});
 
-	if (any_change)
+	if (!any_change)
 	{
-		write_to_disk();
+		console::info("%s not in kill list, doing nothing", remove.data());
+		return;
 	}
-	else
-	{
-		console::info("%s not kill list, not doing anything", remove.data());
-	}
+
+	write_to_disk();
 }
 
 void kill_list::reload_from_disk()
 {
 	std::string contents;
-	
 	if (!utils::io::read_file(kill_file, &contents))
 	{
 		console::info("Could not find %s, no kill list will be loaded.", kill_file.data());

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -1,0 +1,122 @@
+#include "std_include.hpp"
+#include "kill_list.hpp"
+#include "utils/io.hpp"
+#include "utils/string.hpp"
+
+bool kill_list::contains(const network::address& address, OUT std::string& reason)
+{
+	std::string str_address = address.to_string();
+
+	// Lock the list so it doesn't move while we search
+	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
+
+	if (entries.find(str_address) != entries.end())
+	{
+		auto entry = entries.at(str_address);
+
+		reason = entry.reason;
+		return true;
+	}
+
+	return false;
+}
+
+void kill_list::add_to_kill_list(const kill_list::kill_list_entry& add)
+{
+	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
+	entries.emplace(add.ip_address, add);
+	console::info(utils::string::va("Added %s to kill list (reason: %s)", add.ip_address.data(), add.reason.data()));
+	write_to_disk();
+}
+
+void kill_list::remove_from_kill_list(const network::address& remove)
+{
+	remove_from_kill_list(remove.to_string());
+}
+
+void kill_list::remove_from_kill_list(const std::string& remove)
+{
+	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
+	if (entries.erase(remove))
+	{
+		console::info(utils::string::va("Removed %s from kill list", remove.data()));
+		write_to_disk();
+	}
+}
+
+void kill_list::reload_from_disk()
+{
+	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
+
+	if (utils::io::file_exists(kill_file))
+	{
+		std::string contents = utils::io::read_file(kill_file);
+
+		std::istringstream string_stream(contents);
+		std::string line;
+
+		entries.clear();
+		while (std::getline(string_stream, line)) {
+			if (line[0] == '#')
+			{
+				// comments or ignored line
+				continue;
+			}
+
+			std::string ip;
+			std::string comment{};
+
+			auto index = line.find(' ');
+			if (line.find(' ') != std::string::npos)
+			{
+				ip = line.substr(0, index);
+				comment = line.substr(index + 1);
+			}
+			else
+			{
+				ip = line;
+			}
+
+			if (ip.empty())
+			{
+				continue;
+			}
+
+			// Double line breaks from windows' \r\n
+			if (ip[ip.size() - 1] == '\r')
+			{
+				ip.pop_back();
+			}
+
+			entries.emplace(ip, kill_list::kill_list_entry(ip, comment));
+		}
+
+		console::info(utils::string::va("Loaded %i kill list entries from %s", entries.size(), kill_file.data()));
+	}
+	else
+	{
+		console::info(utils::string::va("Could not find %s, no kill list will be loaded.", kill_file.data()));
+	}
+}
+
+void kill_list::write_to_disk()
+{
+	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
+
+	utils::io::remove_file(kill_file);
+
+	std::ostringstream stream;
+	for (auto kv : entries)
+	{
+		auto entry = kv.second;
+		stream << entry.ip_address << " " << entry.reason << "\n";
+	}
+
+	utils::io::write_file(kill_file, stream.str());
+	console::info(utils::string::va("Wrote %s to disk (%i entries)", kill_file.data(), entries.size()));
+}
+
+kill_list::kill_list(server& server) : service(server)
+{
+	reload_from_disk();
+}

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -28,7 +28,7 @@ void kill_list::add_to_kill_list(const kill_list::kill_list_entry& add)
 	if (entries.find(add.ip_address) == entries.end())
 	{
 		entries.emplace(add.ip_address, add);
-		console::info(utils::string::va("Added %s to kill list (reason: %s)", add.ip_address.data(), add.reason.data()));
+		console::info("Added %s to kill list (reason: %s)", add.ip_address.data(), add.reason.data());
 		write_to_disk();
 	}
 }
@@ -43,7 +43,7 @@ void kill_list::remove_from_kill_list(const std::string& remove)
 	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
 	if (entries.erase(remove))
 	{
-		console::info(utils::string::va("Removed %s from kill list", remove.data()));
+		console::info("Removed %s from kill list", remove.data());
 		write_to_disk();
 	}
 }
@@ -96,11 +96,11 @@ void kill_list::reload_from_disk()
 			entries.emplace(ip, kill_list::kill_list_entry(ip, comment));
 		}
 
-		console::info(utils::string::va("Loaded %i kill list entries from %s", entries.size(), kill_file.data()));
+		console::info("Loaded %i kill list entries from %s", entries.size(), kill_file.data());
 	}
 	else
 	{
-		console::info(utils::string::va("Could not find %s, no kill list will be loaded.", kill_file.data()));
+		console::info("Could not find %s, no kill list will be loaded.", kill_file.data());
 	}
 }
 
@@ -118,7 +118,7 @@ void kill_list::write_to_disk()
 	}
 
 	utils::io::write_file(kill_file, stream.str());
-	console::info(utils::string::va("Wrote %s to disk (%i entries)", kill_file.data(), entries.size()));
+	console::info("Wrote %s to disk (%i entries)", kill_file.data(), entries.size());
 }
 
 kill_list::kill_list(server& server) : service(server)

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -23,21 +23,17 @@ bool kill_list::contains(const network::address& address, std::string& reason)
 
 void kill_list::add_to_kill_list(kill_list::kill_list_entry add)
 {
-	bool any_change = false;
-	entries_container.access([&add, &any_change](kill_list_entries& entries)
+	bool any_change = entries_container.access<bool>([&add, &any_change](kill_list_entries& entries)
 		{
 			auto existing_entry = entries.find(add.ip_address);
 			if (existing_entry == entries.end() || existing_entry->second.reason != add.reason)
 			{
-				if (existing_entry != entries.end())
-				{
-					entries.erase(existing_entry);
-				}
-
-				entries.emplace(add.ip_address, std::move(add));
+				entries[add.ip_address] = std::move(add);
 				console::info("Added %s to kill list (reason: %s)", add.ip_address.data(), add.reason.data());
-				any_change = true;
+				return true;
 			}
+
+			return false;
 		});
 
 	if (any_change)
@@ -57,14 +53,15 @@ void kill_list::remove_from_kill_list(const network::address& remove)
 
 void kill_list::remove_from_kill_list(const std::string& remove)
 {
-	bool any_change = false;
-	entries_container.access([&remove, &any_change](kill_list_entries& entries)
+	bool any_change = entries_container.access<bool>([&remove, &any_change](kill_list_entries& entries)
 	{
 		if (entries.erase(remove))
 		{
 			console::info("Removed %s from kill list", remove.data());
-			any_change = true;
+			return true;
 		}
+
+		return false;
 	});
 
 	if (any_change)
@@ -79,58 +76,59 @@ void kill_list::remove_from_kill_list(const std::string& remove)
 
 void kill_list::reload_from_disk()
 {
-	if (!utils::io::file_exists(kill_file))
+	std::string contents;
+	
+	if (utils::io::read_file(kill_file, &contents))
+	{
+		std::istringstream string_stream(contents);
+		std::string line;
+
+		entries_container.access([&string_stream, &line, this](kill_list_entries& entries)
+			{
+				entries.clear();
+				while (std::getline(string_stream, line))
+				{
+					if (line[0] == '#')
+					{
+						// comments or ignored line
+						continue;
+					}
+
+					std::string ip;
+					std::string comment;
+
+					auto index = line.find(' ');
+					if (line.find(' ') != std::string::npos)
+					{
+						ip = line.substr(0, index);
+						comment = line.substr(index + 1);
+					}
+					else
+					{
+						ip = line;
+					}
+
+					if (ip.empty())
+					{
+						continue;
+					}
+
+					// Double line breaks from windows' \r\n
+					if (ip[ip.size() - 1] == '\r')
+					{
+						ip.pop_back();
+					}
+
+					entries.emplace(ip, kill_list::kill_list_entry(ip, comment));
+				}
+
+				console::info("Loaded %i kill list entries from %s", entries.size(), kill_file.data());
+			});
+	}
+	else 
 	{
 		console::info("Could not find %s, no kill list will be loaded.", kill_file.data());
-		return;
 	}
-
-	std::string contents = utils::io::read_file(kill_file);
-
-	std::istringstream string_stream(contents);
-	std::string line;
-
-	entries_container.access([&string_stream, &line, this](kill_list_entries& entries)
-	{
-		entries.clear();
-		while (std::getline(string_stream, line))
-		{
-			if (line[0] == '#')
-			{
-				// comments or ignored line
-				continue;
-			}
-
-			std::string ip;
-			std::string comment;
-
-			auto index = line.find(' ');
-			if (line.find(' ') != std::string::npos)
-			{
-				ip = line.substr(0, index);
-				comment = line.substr(index + 1);
-			}
-			else
-			{
-				ip = line;
-			}
-
-			if (ip.empty())
-			{
-				continue;
-			}
-
-			// Double line breaks from windows' \r\n
-			if (ip[ip.size() - 1] == '\r')
-			{
-				ip.pop_back();
-			}
-
-			entries.emplace(ip, kill_list::kill_list_entry(ip, comment));
-		}
-
-		console::info("Loaded %i kill list entries from %s", entries.size(), kill_file.data());
-	});
 }
 
 void kill_list::write_to_disk()

--- a/src/services/kill_list.cpp
+++ b/src/services/kill_list.cpp
@@ -6,31 +6,34 @@
 bool kill_list::contains(const network::address& address, std::string& reason)
 {
 	std::string str_address = address.to_string();
+	bool contains = false;
 
-	// Lock the list so it doesn't move while we search
-	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
+	entries_container.access([str_address, &reason, &contains](const kill_list_entries& entries)
+		{
+			if (entries.find(str_address) != entries.end())
+			{
+				auto entry = entries.at(str_address);
 
-	if (entries.find(str_address) != entries.end())
-	{
-		auto entry = entries.at(str_address);
+				reason = entry.reason;
+				contains = true;
+			}
+		});
 
-		reason = entry.reason;
-		return true;
-	}
-
-	return false;
+	return contains;
 }
 
-void kill_list::add_to_kill_list(const kill_list::kill_list_entry& add)
+void kill_list::add_to_kill_list(kill_list::kill_list_entry add)
 {
-	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
+	entries_container.access([&add, this](kill_list_entries& entries)
+		{
+			if (entries.find(add.ip_address) == entries.end())
+			{
+				entries.emplace(add.ip_address, add);
+				console::info("Added %s to kill list (reason: %s)", add.ip_address.data(), add.reason.data());
+			}
+		});
 
-	if (entries.find(add.ip_address) == entries.end())
-	{
-		entries.emplace(add.ip_address, add);
-		console::info("Added %s to kill list (reason: %s)", add.ip_address.data(), add.reason.data());
-		write_to_disk();
-	}
+	write_to_disk();
 }
 
 void kill_list::remove_from_kill_list(const network::address& remove)
@@ -40,18 +43,19 @@ void kill_list::remove_from_kill_list(const network::address& remove)
 
 void kill_list::remove_from_kill_list(const std::string& remove)
 {
-	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
-	if (entries.erase(remove))
+	entries_container.access([&remove, this](kill_list_entries& entries)
 	{
-		console::info("Removed %s from kill list", remove.data());
-		write_to_disk();
-	}
+		if (entries.erase(remove))
+		{
+			console::info("Removed %s from kill list", remove.data());
+		}
+	});
+
+	write_to_disk();
 }
 
 void kill_list::reload_from_disk()
 {
-	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
-
 	if (utils::io::file_exists(kill_file))
 	{
 		std::string contents = utils::io::read_file(kill_file);
@@ -59,44 +63,47 @@ void kill_list::reload_from_disk()
 		std::istringstream string_stream(contents);
 		std::string line;
 
-		entries.clear();
-		while (std::getline(string_stream, line)) 
+		entries_container.access([&string_stream, &line, this](kill_list_entries& entries)
 		{
-			if (line[0] == '#')
+			entries.clear();
+			while (std::getline(string_stream, line))
 			{
-				// comments or ignored line
-				continue;
+				if (line[0] == '#')
+				{
+					// comments or ignored line
+					continue;
+				}
+
+				std::string ip;
+				std::string comment{};
+
+				auto index = line.find(' ');
+				if (line.find(' ') != std::string::npos)
+				{
+					ip = line.substr(0, index);
+					comment = line.substr(index + 1);
+				}
+				else
+				{
+					ip = line;
+				}
+
+				if (ip.empty())
+				{
+					continue;
+				}
+
+				// Double line breaks from windows' \r\n
+				if (ip[ip.size() - 1] == '\r')
+				{
+					ip.pop_back();
+				}
+
+				entries.emplace(ip, kill_list::kill_list_entry(ip, comment));
 			}
 
-			std::string ip;
-			std::string comment{};
-
-			auto index = line.find(' ');
-			if (line.find(' ') != std::string::npos)
-			{
-				ip = line.substr(0, index);
-				comment = line.substr(index + 1);
-			}
-			else
-			{
-				ip = line;
-			}
-
-			if (ip.empty())
-			{
-				continue;
-			}
-
-			// Double line breaks from windows' \r\n
-			if (ip[ip.size() - 1] == '\r')
-			{
-				ip.pop_back();
-			}
-
-			entries.emplace(ip, kill_list::kill_list_entry(ip, comment));
-		}
-
-		console::info("Loaded %i kill list entries from %s", entries.size(), kill_file.data());
+			console::info("Loaded %i kill list entries from %s", entries.size(), kill_file.data());
+		});
 	}
 	else
 	{
@@ -106,19 +113,20 @@ void kill_list::reload_from_disk()
 
 void kill_list::write_to_disk()
 {
-	std::lock_guard<std::recursive_mutex> _(kill_list_mutex);
-
 	utils::io::remove_file(kill_file);
 
 	std::ostringstream stream;
-	for (auto kv : entries)
+	entries_container.access([&stream, this](kill_list_entries& entries)
 	{
-		auto entry = kv.second;
-		stream << entry.ip_address << " " << entry.reason << "\n";
-	}
+		for (auto kv : entries)
+		{
+			auto entry = kv.second;
+			stream << entry.ip_address << " " << entry.reason << "\n";
+		}
 
-	utils::io::write_file(kill_file, stream.str());
-	console::info("Wrote %s to disk (%i entries)", kill_file.data(), entries.size());
+		utils::io::write_file(kill_file, stream.str());
+		console::info("Wrote %s to disk (%i entries)", kill_file.data(), entries.size());
+	});
 }
 
 kill_list::kill_list(server& server) : service(server)

--- a/src/services/kill_list.hpp
+++ b/src/services/kill_list.hpp
@@ -5,9 +5,6 @@
 class kill_list : public service
 {
 public:
-
-	using service::service;
-
 	class kill_list_entry
 	{
 	public:
@@ -27,7 +24,7 @@ public:
 
 private:
 	using kill_list_entries = std::unordered_map<std::string, kill_list_entry>;
-	utils::concurrency::container<kill_list_entries> entries_container;
+	utils::concurrency::container<kill_list_entries> entries_container_;
 
 	void reload_from_disk();
 	void write_to_disk();

--- a/src/services/kill_list.hpp
+++ b/src/services/kill_list.hpp
@@ -25,14 +25,14 @@ public:
 	kill_list(server& server);
 
 	bool contains(const network::address& address, std::string& reason);
-	void add_to_kill_list(const kill_list::kill_list_entry& add);
+	void add_to_kill_list(kill_list::kill_list_entry add);
 	void remove_from_kill_list(const network::address& remove);
 	void remove_from_kill_list(const std::string& remove);
 
 private:
 	std::string secret_;
-	std::unordered_map<std::string, kill_list_entry> entries;
+	using kill_list_entries = std::unordered_map<std::string, kill_list_entry>;
+	utils::concurrency::container<kill_list_entries> entries_container;
 	void reload_from_disk();
 	void write_to_disk();
-	std::recursive_mutex kill_list_mutex;
 };

--- a/src/services/kill_list.hpp
+++ b/src/services/kill_list.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "network/address.hpp"
+#include "../service.hpp"
+
+class kill_list : public service
+{
+public:
+
+	using service::service;
+
+	struct kill_list_entry
+	{
+		std::string ip_address;
+		std::string reason;
+
+		kill_list_entry(std::string ip_address, std::string reason)
+		{
+			this->ip_address = ip_address;
+			this->reason = reason;
+		}
+	};
+
+	const std::string kill_file = "./KILL.TXT";
+
+	kill_list(server& server);
+
+	bool contains(const network::address& address, std::string& reason);
+	void add_to_kill_list(const kill_list::kill_list_entry& add);
+	void remove_from_kill_list(const network::address& remove);
+	void remove_from_kill_list(const std::string& remove);
+
+private:
+	std::string secret_;
+	std::unordered_map<std::string, kill_list_entry> entries;
+	void reload_from_disk();
+	void write_to_disk();
+	std::recursive_mutex kill_list_mutex;
+};

--- a/src/services/kill_list.hpp
+++ b/src/services/kill_list.hpp
@@ -18,8 +18,6 @@ public:
 		std::string reason_;
 	};
 
-	const std::string kill_file = "./kill.txt";
-
 	kill_list(server& server);
 
 	bool contains(const network::address& address, std::string& reason);
@@ -28,7 +26,6 @@ public:
 	void remove_from_kill_list(const std::string& remove);
 
 private:
-	std::string secret_;
 	using kill_list_entries = std::unordered_map<std::string, kill_list_entry>;
 	utils::concurrency::container<kill_list_entries> entries_container;
 

--- a/src/services/kill_list.hpp
+++ b/src/services/kill_list.hpp
@@ -20,7 +20,7 @@ public:
 		}
 	};
 
-	const std::string kill_file = "./KILL.TXT";
+	const std::string kill_file = "./kill.txt";
 
 	kill_list(server& server);
 

--- a/src/services/kill_list.hpp
+++ b/src/services/kill_list.hpp
@@ -8,16 +8,14 @@ public:
 
 	using service::service;
 
-	struct kill_list_entry
+	class kill_list_entry
 	{
-		std::string ip_address;
-		std::string reason;
+	public:
+		kill_list_entry() = default;
+		kill_list_entry(std::string ip_address, std::string reason);
 
-		kill_list_entry(std::string ip_address, std::string reason)
-		{
-			this->ip_address = ip_address;
-			this->reason = reason;
-		}
+		std::string ip_address_;
+		std::string reason_;
 	};
 
 	const std::string kill_file = "./kill.txt";
@@ -25,7 +23,7 @@ public:
 	kill_list(server& server);
 
 	bool contains(const network::address& address, std::string& reason);
-	void add_to_kill_list(kill_list::kill_list_entry add);
+	void add_to_kill_list(kill_list_entry add);
 	void remove_from_kill_list(const network::address& remove);
 	void remove_from_kill_list(const std::string& remove);
 
@@ -33,6 +31,7 @@ private:
 	std::string secret_;
 	using kill_list_entries = std::unordered_map<std::string, kill_list_entry>;
 	utils::concurrency::container<kill_list_entries> entries_container;
+
 	void reload_from_disk();
 	void write_to_disk();
 };

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -19,7 +19,7 @@ void patch_kill_list_command::handle_command([[maybe_unused]] const network::add
 	const utils::parameters params(data);
 	if (params.size() < 3)
 	{
-		throw execution_exception{ "Invalid parameter count" };
+		throw execution_exception("Invalid parameter count");
 	}
 	
 	const auto& signature = utils::cryptography::base64::decode(params[0]);
@@ -27,16 +27,16 @@ void patch_kill_list_command::handle_command([[maybe_unused]] const network::add
 
 	if (!should_remove && params[1] != "add"s)
 	{
-		throw execution_exception{ "Invalid parameter #2: should be 'add' or 'remove'" };
+		throw execution_exception("Invalid parameter #2: should be 'add' or 'remove'");
 	}
 
-	auto supplied_address = params[2];
+	const auto& supplied_address = params[2];
 
-	std::string supplied_reason{};
+	std::string supplied_reason;
 
 	if (params.size() > 4)
 	{
-		for (size_t i = 3; i < params.size(); i++)
+		for (size_t i = 3; i < params.size(); ++i)
 		{
 			supplied_reason += params[i] + " ";
 		}
@@ -46,7 +46,7 @@ void patch_kill_list_command::handle_command([[maybe_unused]] const network::add
 
 	if (!utils::cryptography::ecc::verify_message(crypto_key, supplied_address, signature))
 	{
-		throw execution_exception{ "Signature verification of the kill list patch key failed" };
+		throw execution_exception("Signature verification of the kill list patch key failed");
 	}
 
 	auto kill_list_service = this->get_server().get_service<kill_list>();

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -40,11 +40,6 @@ void patch_kill_list_command::handle_command([[maybe_unused]] const network::add
 		supplied_address = supplied_address.substr(1);
 	}
 
-
-	auto challenge = utils::cryptography::random::get_challenge();
-	auto heartbeat = std::chrono::high_resolution_clock::now();
-
-
 	auto crypto_key = crypto_key::get(); 
 
 	if (!utils::cryptography::ecc::verify_message(crypto_key, params[1], signature))

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -1,0 +1,67 @@
+#include <std_include.hpp>
+#include "patch_kill_list_command.hpp"
+
+#include "services/kill_list.hpp"
+
+#include "utils/string.hpp"
+#include "utils/parameters.hpp"
+
+const char* patch_kill_list_command::get_command() const
+{
+	return "patchkill";
+}
+
+void patch_kill_list_command::handle_command(const network::address& target, const std::string_view& data)
+{
+	auto key = std::getenv("KILL_LIST_PATCH_SECRET_KEY");
+
+	if (strnlen(key, 128) == 0)
+	{
+		// No kill list secret defined, no patching possible
+		return;
+	}
+
+	const utils::parameters params(data);
+	if (params.size() < 2)
+	{
+		throw execution_exception{ "Invalid parameter count" };
+	}
+
+	const auto& supplied_key = params[0];
+	
+	auto supplied_address = params[1];
+
+	std::string supplied_reason{};
+
+	if (params.size() > 3)
+	{
+		supplied_reason = params[2];
+	}
+
+	bool should_remove = false;
+
+	if (supplied_address[0] == '-')
+	{
+		should_remove = true;
+		supplied_address = supplied_address.substr(1);
+	}
+
+
+	if (supplied_key == key)
+	{
+		auto kill_list_service = this->get_server().get_service<kill_list>();
+
+		if (should_remove)
+		{
+			kill_list_service->remove_from_kill_list(supplied_address);
+		}
+		else
+		{
+			kill_list_service->add_to_kill_list(const kill_list::kill_list_entry(supplied_address, supplied_reason));
+		}
+	}
+	else
+	{
+		console::warn(utils::string::va("Rejected kill list patch because the supplied key (%s) was wrong", supplied_key.data()));
+	}
+}

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -42,7 +42,7 @@ void patch_kill_list_command::handle_command([[maybe_unused]] const network::add
 	{
 		// No kill list secret defined, no patching possible
 		return;
-}
+	}
 
 
 	const utils::parameters params(data);

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -56,7 +56,7 @@ void patch_kill_list_command::handle_command(const network::address& target, con
 		}
 		else
 		{
-			kill_list_service->add_to_kill_list(const kill_list::kill_list_entry(supplied_address, supplied_reason));
+			kill_list_service->add_to_kill_list(kill_list::kill_list_entry(supplied_address, supplied_reason));
 		}
 	}
 	else

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -17,7 +17,7 @@ void patch_kill_list_command::handle_command(const network::address& target, con
 
 	size_t size;
 	char key_buff[128];
-	errno_t result = getenv_s(&size, key_buff, 128, key_env_name.data());
+	auto result = getenv_s(&size, key_buff, 128, key_env_name.data());
 
 	if (size > 0) {
 

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -13,9 +13,18 @@ const char* patch_kill_list_command::get_command() const
 
 void patch_kill_list_command::handle_command(const network::address& target, const std::string_view& data)
 {
-	auto key = std::getenv("KILL_LIST_PATCH_SECRET_KEY");
+	
+	std::string key;
+	char* buf = nullptr;
+	size_t sz = 0;
+	
+	if (_dupenv_s(&buf, &sz, "KILL_LIST_PATCH_SECRET_KEY") == 0 && buf != nullptr)
+	{
+		key = buf;
+		free(buf);
+	}
 
-	if (strnlen(key, 128) == 0)
+	if (sz == 0)
 	{
 		// No kill list secret defined, no patching possible
 		return;
@@ -61,6 +70,6 @@ void patch_kill_list_command::handle_command(const network::address& target, con
 	}
 	else
 	{
-		console::warn(utils::string::va("Rejected kill list patch because the supplied key (%s) was wrong", supplied_key.data()));
+		console::warn("Rejected kill list patch because the supplied key (%s) was wrong", supplied_key.data());
 	}
 }

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -13,18 +13,24 @@ const char* patch_kill_list_command::get_command() const
 
 void patch_kill_list_command::handle_command(const network::address& target, const std::string_view& data)
 {
-	
 	std::string key;
-	char* buf = nullptr;
-	size_t sz = 0;
-	
-	if (_dupenv_s(&buf, &sz, "KILL_LIST_PATCH_SECRET_KEY") == 0 && buf != nullptr)
-	{
-		key = buf;
-		free(buf);
-	}
 
-	if (sz == 0)
+	size_t size;
+	char key_buff[128];
+	errno_t result = getenv_s(&size, key_buff, 128, key_env_name.data());
+
+	if (size > 0) {
+
+		if (result == 0)
+		{
+			key = key_buff;
+		}
+		else
+		{
+			console::error("Error %i when trying to get the key from env %s", result, key_env_name.data());
+		}
+	}
+	else
 	{
 		// No kill list secret defined, no patching possible
 		return;

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -44,7 +44,7 @@ void patch_kill_list_command::handle_command([[maybe_unused]] const network::add
 
 	const auto supplied_reason = params.join(4);
 	const auto& crypto_key = crypto_key::get(); 
-	const std::string signature_candidate = std::to_string(supplied_timestamp.count());
+	const auto signature_candidate = std::to_string(supplied_timestamp.count());
 
 	if (!utils::cryptography::ecc::verify_message(crypto_key, signature_candidate, signature))
 	{

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -28,7 +28,6 @@ void patch_kill_list_command::handle_command(const network::address& target, con
 	}
 
 	const auto& supplied_key = params[0];
-	
 	auto supplied_address = params[1];
 
 	std::string supplied_reason{};
@@ -40,7 +39,7 @@ void patch_kill_list_command::handle_command(const network::address& target, con
 
 	bool should_remove = false;
 
-	if (supplied_address[0] == '-')
+	if (supplied_address[0] == '-') // e.g.  -1.2.3.4 removes it from the list, while 1.2.3.4 adds it to the list
 	{
 		should_remove = true;
 		supplied_address = supplied_address.substr(1);

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -4,9 +4,8 @@
 #include "crypto_key.hpp"
 #include "services/kill_list.hpp"
 
-#include "utils/string.hpp"
-#include "utils/parameters.hpp"
-#include "utils/io.hpp"
+#include <utils/parameters.hpp>
+#include <utils/io.hpp>
 
 const char* patch_kill_list_command::get_command() const
 {
@@ -42,14 +41,14 @@ void patch_kill_list_command::handle_command([[maybe_unused]] const network::add
 		}
 	}
 
-	auto crypto_key = crypto_key::get(); 
+	const auto& crypto_key = crypto_key::get(); 
 
 	if (!utils::cryptography::ecc::verify_message(crypto_key, supplied_address, signature))
 	{
 		throw execution_exception("Signature verification of the kill list patch key failed");
 	}
 
-	auto kill_list_service = this->get_server().get_service<kill_list>();
+	const auto kill_list_service = this->get_server().get_service<kill_list>();
 
 	if (should_remove)
 	{

--- a/src/services/patch_kill_list_command.cpp
+++ b/src/services/patch_kill_list_command.cpp
@@ -65,7 +65,7 @@ void patch_kill_list_command::handle_command([[maybe_unused]] const network::add
 		}
 		else
 		{
-			kill_list_service->add_to_kill_list(std::move(kill_list::kill_list_entry(supplied_address, supplied_reason)));
+			kill_list_service->add_to_kill_list(kill_list::kill_list_entry(supplied_address, supplied_reason));
 		}
 	}
 	else

--- a/src/services/patch_kill_list_command.hpp
+++ b/src/services/patch_kill_list_command.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../service.hpp"
+
+class patch_kill_list_command : public service
+{
+public:
+	using service::service;
+
+	const char* get_command() const override;
+	void handle_command(const network::address& target, const std::string_view& data) override;
+};

--- a/src/services/patch_kill_list_command.hpp
+++ b/src/services/patch_kill_list_command.hpp
@@ -11,5 +11,5 @@ public:
 	void handle_command(const network::address& target, const std::string_view& data) override;
 
 private:
-	const std::string key_env_name = "KILL_LIST_PATCH_SECRET_KEY";
+	const std::string key_file_name = "KILL_LIST_PATCH_SECRET_KEY.TXT";
 };

--- a/src/services/patch_kill_list_command.hpp
+++ b/src/services/patch_kill_list_command.hpp
@@ -9,7 +9,4 @@ public:
 
 	const char* get_command() const override;
 	void handle_command(const network::address& target, const std::string_view& data) override;
-
-private:
-	const std::string key_file_name = "KILL_LIST_PATCH_SECRET_KEY.TXT";
 };

--- a/src/services/patch_kill_list_command.hpp
+++ b/src/services/patch_kill_list_command.hpp
@@ -9,4 +9,7 @@ public:
 
 	const char* get_command() const override;
 	void handle_command(const network::address& target, const std::string_view& data) override;
+
+private:
+	const std::string key_env_name = "KILL_LIST_PATCH_SECRET_KEY";
 };

--- a/src/std_include.hpp
+++ b/src/std_include.hpp
@@ -49,7 +49,6 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <stdlib.h>
 
 #define ZeroMemory(x, y) memset(x, 0, y)
 

--- a/src/std_include.hpp
+++ b/src/std_include.hpp
@@ -49,6 +49,7 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <stdlib.h>
 
 #define ZeroMemory(x, y) memset(x, 0, y)
 


### PR DESCRIPTION
On iw4x - and maybe other clients - people use the master server to advertise their discord with locked servers or fake player count, we would like to have a way to handle these issues easily by banning target IPs from the master server.

This should be extremely simple to do and require no redeploy/pr/snake intervention, cause if it takes more effort to update the kill list than it takes malicious hosters to change their IP, it won't be useful.

So I implemented a very simple kill list TXT the server writes to and reads from, and that can be very easily updated with a patch command sent with a secret key (stored in ENV in serverside). Ultimately we could have the XLabs discord bot send that message on demand (so the bot would have the secret key), so that we could in the admin channel update the kill list with just a single discord message. Very neat!

The kill list also supports adding a reason to any kill line so that we can remember why a certain ip is removed or not.

**Note: This builds and runs, but I have yet to test it in different edge cases to make sure it is 100% OK**